### PR TITLE
fixed width and height arguments

### DIFF
--- a/src/Tags/ResponsiveImageTag.php
+++ b/src/Tags/ResponsiveImageTag.php
@@ -244,8 +244,8 @@ class ResponsiveImageTag extends Tags
 			"alt" => $alt,
 			"srcsets" => $reversed_srcsets,
 			"class" => $class,
-			"height" => $srcsets[0]["width"],
-			"width" => $srcsets[0]["height"],
+			"width" => $srcsets[0]["width"],
+			"height" => $srcsets[0]["height"],
 			"placeholder" => $this->getPlaceholder($srcsets[0]["width"], $srcsets[0]["height"], $dominant_color),
 		]);
 	}


### PR DESCRIPTION
Width and height were mixed in the args array for the responsiveImage view. This results in reversed aspect ratios for placeholders, which in turn might make problems in situations where container heights are calculated on pageload (as in Swiper).